### PR TITLE
Updated build toolchain to support VS2013.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -86,16 +86,25 @@ if defined noperfctr set noperfctr_arg=--without-perfctr& set noperfctr_msi_arg=
 :project-gen
 if defined NIGHTLY set TAG=nightly-%NIGHTLY%
 SETLOCAL
-	if defined VS100COMNTOOLS if exist "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat" (
-		call "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat"
-		set GYP_MSVS_VERSION=2010
-		set platformtoolset=v100
+	if defined VS120COMNTOOLS if exist "%VS120COMNTOOLS%\VCVarsQueryRegistry.bat" (
+		echo Configuring Platform Toolset V120
+		call "%VS120COMNTOOLS%\VCVarsQueryRegistry.bat"
+		set GYP_MSVS_VERSION=2013
+		set platformtoolset=v120
 		goto inner-config
 	)
 	if defined VS110COMNTOOLS if exist "%VS110COMNTOOLS%\VCVarsQueryRegistry.bat" (
+		echo Configuring Platform Toolset V110
 		call "%VS110COMNTOOLS%\VCVarsQueryRegistry.bat"
 		set GYP_MSVS_VERSION=2012
 		set platformtoolset=v110
+		goto inner-config
+	)
+	if defined VS100COMNTOOLS if exist "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat" (
+		echo Configuring Platform Toolset V100
+		call "%VS100COMNTOOLS%\VCVarsQueryRegistry.bat"
+		set GYP_MSVS_VERSION=2010
+		set platformtoolset=v100
 		goto inner-config
 	)
 	echo Cannot find visual studio VCVarsQueryRegistry.bat
@@ -110,11 +119,12 @@ ENDLOCAL
 :msbuild
 if defined nobuild goto sign
 SETLOCAL
-	if defined VS100COMNTOOLS if exist "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat" (
-		echo Using Platform Toolset V100
-		call "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat"
-		set GYP_MSVS_VERSION=2010
-		set platformtoolset=v100
+
+	if defined VS120COMNTOOLS if exist "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat" (
+		echo Using Platform Toolset V120
+		call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat"
+		set GYP_MSVS_VERSION=2013
+		set platformtoolset=v120
 		goto msbuild-found
 	)
 	if defined VS110COMNTOOLS if exist "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat" (
@@ -122,6 +132,13 @@ SETLOCAL
 		call "%VS110COMNTOOLS%\..\..\vc\vcvarsall.bat"
 		set GYP_MSVS_VERSION=2012
 		set platformtoolset=v110
+		goto msbuild-found
+	)
+	if defined VS100COMNTOOLS if exist "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat" (
+		echo Using Platform Toolset V100
+		call "%VS100COMNTOOLS%\..\..\vc\vcvarsall.bat"
+		set GYP_MSVS_VERSION=2010
+		set platformtoolset=v100
 		goto msbuild-found
 	)
 	echo Cannot find vcvarsall.bat for visual studio

--- a/config.bat
+++ b/config.bat
@@ -17,33 +17,9 @@ set hostarch=x86
 set arch=x64
 if /i "%1"=="x86" set arch=ia32
 
-:GetWindowsSdkDir
-@call :GetWindowsSdkDirHelper HKLM
-@if errorlevel 1 call :GetWindowsSdkDirHelper HKCU
-@if errorlevel 1 echo WindowsSdkDir not found
-@exit /B 0
-
-:GetWindowsSdkDirHelper
-:: Microsoft Windows SDK regkey differs depending on the architecture
-@SET RegPath=
-if "%hostarch%"=="x64" SET RegPath=Wow6432Node\
-@SET WindowsSdkDir=
-@for /F "tokens=1,2*" %%i in ('reg query "%1\SOFTWARE\%RegPath%Microsoft\Microsoft SDKs\Windows" /v "CurrentInstallFolder"') DO (
-if "%%i"=="CurrentInstallFolder" (
-echo Using Windows SDK @ %%k
-SET "WindowsSdkDir=%%k"
-)
-)
-@if "%WindowsSdkDir%"=="" exit /B 1
-
 set newpath=C:\Python27;C:\Python26;C:\Python
 echo %path%|findstr /i /c:"python">nul  || set path=%path%;%newpath%
 
-set newincludepath=%WindowsSdkDir%include
-set newlibpath=%WindowsSdkDir%lib\x64
-if /i "%arch%"=="ia32" set newlibpath=%WindowsSdkDir%lib
-echo %libpath%|findstr /i /c:"Microsoft SDKs\Windows">nul  || set libpath=%libpath%;%newlibpath%
-echo Windows SDK Library Path %newlibpath%
 echo Architecture %arch% (host architecture %hostarch%)
 
 if NOT exist .\libraries\node\node.gyp (


### PR DESCRIPTION
Compile only works on command line; not yet supported from directly
inside VS2013 build (usually you’ll need to build first outside, then
go into VS2013).